### PR TITLE
Macros `fail!` is now `panic!`

### DIFF
--- a/src/picotcp/pico_stack.rs
+++ b/src/picotcp/pico_stack.rs
@@ -144,7 +144,7 @@ impl stack {
         let n;
         unsafe { n = pico_stack_init(); }
         if n < 0 {
-            fail!("PicoTCP: failed to initialize stack\n");
+            panic!("PicoTCP: failed to initialize stack\n");
         }
         let x = stack;
         x


### PR DESCRIPTION
Looks like it's the case with:

```
rustc 0.13.0-nightly (0a5e7f359 2014-11-03 23:16:55 +0000)
```

Not sure which versions you had been using...
